### PR TITLE
swarm: Add timeout on dpkg lock check

### DIFF
--- a/playbooks/swarm.yml
+++ b/playbooks/swarm.yml
@@ -9,6 +9,8 @@
         - lib/dpkg/lock-frontend
         - lib/apt/lists/lock
         - cache/apt/archives/lock
+      # Unattended upgrades can lock the dpkg lock file for long periods of time, so we timeout to skip the host and continue with the rest of the playbook
+      timeout: 60
 
     - name: Update apt
       ansible.builtin.apt:


### PR DESCRIPTION
Add timeout on dpkg lock check, in swarm playbooks. It allow to fail the host if the dpkg is locked but continue to run the playbook on other hosts.

Exemple of long unattended upgrade that freezed the deployment for more than 30m :

```shell
ps fauxw | grep unatt
root         847  0.0  0.0 110104 21228 ?        Ssl  09:14   0:00 /usr/bin/python3 /usr/share/unattended-upgrades/unattended-upgrade-shutdown --wait-for-signal
root        4359 33.1  0.4 352608 191072 ?       Sl   09:17   9:32      \_ /usr/bin/python3 /usr/bin/unattended-upgrade
root       65051  2.1  0.2 352608 122888 ?       S    09:46   0:00          \_ /usr/bin/python3 /usr/bin/unattended-upgrade
root       69725  0.0  0.1 352608 75808 ?        S    09:46   0:00              \_ /usr/bin/python3 /usr/bin/unattended-upgrade
ubuntu     69741  0.0  0.0   7008  2320 pts/4    S+   09:46   0:00              \_ grep --color=auto unatt
```
