### PR TITLE
Remove manual nvidia patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project does NOT adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## 0.4.0
+### Fixed
+- Remove manual nvidia patch on `post_docker` as it is run on boot with udev rule and trigger a docker restart.
+
 ## 0.3.0
 ### Fixed
 - Do not output server without ipv4 in generated inventory

--- a/roles/gpu_post_docker/tasks/main.yml
+++ b/roles/gpu_post_docker/tasks/main.yml
@@ -40,8 +40,3 @@
   register: nvidia_runtime_comment
   when: gpu_type is not defined or gpu_type == 'shared'
   notify: "Restart Docker"
-
-# https://github.com/NVIDIA/nvidia-docker/issues/1730
-- name: Manually patch nvidia devices
-  ansible.builtin.command: /usr/bin/nvidia-ctk system create-dev-char-symlinks --create-all
-  notify: "Restart Docker"


### PR DESCRIPTION
Remove manual nvidia patch on `post_docker` as it is run on boot with udev rule and trigger a docker restart.