### PR TITLE
Add timeout on post apt update dpkg-lock test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project does NOT adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## 0.5.0
+### Changed
+- Add timeout on post apt update dpkg-lock test
+
 ## 0.4.0
 ### Fixed
 - Remove manual nvidia patch on `post_docker` as it is run on boot with udev rule and trigger a docker restart.

--- a/playbooks/swarm.yml
+++ b/playbooks/swarm.yml
@@ -24,6 +24,7 @@
     - name: Wait for /var/lib/dpkg/lock-frontend to be released
       ansible.builtin.shell: while lsof /var/lib/dpkg/lock-frontend ; do sleep 10; done;
       changed_when: false
+      timeout: 60
 
 - name: Install NVIDIA driver
   hosts: docker_swarm_worker


### PR DESCRIPTION
Even with the previous fail on timeout for the dpkg lock, before the apt update, we occured to wait for more than 10 minutes on this step.

If there is a dpkg lock here, we should fail the host after 1m timeout and retry on the next run