### PR TITLE
Aristote Dispatcher Proxy

### DIFF
--- a/roles/docker_swarm/defaults/main.yml
+++ b/roles/docker_swarm/defaults/main.yml
@@ -22,5 +22,6 @@ caddy_key_file_source_path: "{{ undef(hint='caddy_key_file_source_path must be d
 caddyfile_storage_path: /etc/caddy/Caddyfile
 caddy_cert_file_target_path: /etc/ssl/caddy_reverse_proxy/cert.pem
 caddy_key_file_target_path: /etc/ssl/caddy_reverse_proxy/key.pem
+proxy_aristote_dispatcher: false
 aristote_dispatcher_url: "{{ undef(hint='aristote_dispatcher_url must be defined') }}"
 aristote_dispatcher_token: "{{ undef(hint='aristote_dispatcher_token must be defined') }}"

--- a/roles/docker_swarm/defaults/main.yml
+++ b/roles/docker_swarm/defaults/main.yml
@@ -19,5 +19,8 @@ registry_password: ~
 caddy_overlay_network: caddy-overlay
 caddy_cert_file_source_path: "{{ undef(hint='caddy_cert_file_source_path must be defined') }}"
 caddy_key_file_source_path: "{{ undef(hint='caddy_key_file_source_path must be defined') }}"
+caddyfile_storage_path: /etc/caddy/Caddyfile
 caddy_cert_file_target_path: /etc/ssl/caddy_reverse_proxy/cert.pem
 caddy_key_file_target_path: /etc/ssl/caddy_reverse_proxy/key.pem
+aristote_dispatcher_url: "{{ undef(hint='aristote_dispatcher_url must be defined') }}"
+aristote_dispatcher_token: "{{ undef(hint='aristote_dispatcher_token must be defined') }}"

--- a/roles/docker_swarm/tasks/caddy_service.yml
+++ b/roles/docker_swarm/tasks/caddy_service.yml
@@ -28,10 +28,10 @@
       caddy_2: "https://"
       caddy_2.import: "default_response"
     publish:
-      - published_port: 81
+      - published_port: 80
         target_port: 80
         mode: ingress
-      - published_port: 444
+      - published_port: 443
         target_port: 443
         mode: ingress
     networks:

--- a/roles/docker_swarm/tasks/caddy_service.yml
+++ b/roles/docker_swarm/tasks/caddy_service.yml
@@ -1,4 +1,20 @@
 ---
+- name: Ensure caddy parent directory exists
+  ansible.builtin.file:
+    path: "{{ caddyfile_storage_path | dirname }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Create Caddyfile
+  ansible.builtin.template:
+    src: "templates/Caddyfile.j2"
+    dest: "{{ caddyfile_storage_path }}"
+    mode: 0644
+    owner: root
+    group: root
+
 - name: Create caddy service
   docker_swarm_service:
     name: caddy
@@ -12,14 +28,16 @@
       caddy_2: "https://"
       caddy_2.import: "default_response"
     publish:
-      - published_port: 80
+      - published_port: 81
         target_port: 80
         mode: ingress
-      - published_port: 443
+      - published_port: 444
         target_port: 443
         mode: ingress
     networks:
       - "{{ caddy_overlay_network }}"
+    env:
+      - CADDY_DOCKER_CADDYFILE_PATH=/etc/caddy/Caddyfile
     mounts:
       - source: /var/run/docker.sock
         target: /var/run/docker.sock
@@ -30,6 +48,10 @@
         readonly: yes
       - source: "{{ caddy_key_file_source_path }}"
         target: "{{ caddy_key_file_target_path }}"
+        type: bind
+        readonly: yes
+      - source: "{{ caddyfile_storage_path }}"
+        target: "/etc/caddy/Caddyfile"
         type: bind
         readonly: yes
     placement:

--- a/roles/docker_swarm/templates/Caddyfile.j2
+++ b/roles/docker_swarm/templates/Caddyfile.j2
@@ -1,0 +1,7 @@
+http://caddy {
+        tls internal
+        reverse_proxy {{ aristote_dispatcher_url}} {
+                header_up Host {upstream_hostport}
+                header_up Authorization "Bearer {{ aristote_dispatcher_token }}"
+        }
+}

--- a/roles/docker_swarm/templates/Caddyfile.j2
+++ b/roles/docker_swarm/templates/Caddyfile.j2
@@ -1,7 +1,9 @@
-http://caddy {
+{% if proxy_aristote_dispatcher %}
+aristote_dispatcher_token
         tls internal
         reverse_proxy {{ aristote_dispatcher_url}} {
                 header_up Host {upstream_hostport}
                 header_up Authorization "Bearer {{ aristote_dispatcher_token }}"
         }
 }
+{% endif %}


### PR DESCRIPTION
# New feature

Aristote Dispatcher Proxy using existing caddy.
Aristote Dispatcher is now accessible using http://caddy, and bearer token will be automatically added by Caddy using the token provided in configuration.

Three new variables:
- `proxy_aristote_dispatcher` (bool, default=false): Enable feature
- `aristote_dispatcher_url` (string, optional): URL of Aristote Dispatcher
- `aristote_dispatcher_token` (string, optional): Token used by Caddy