### PR TITLE
Fix ssh keys provisionning

### DIFF
--- a/playbooks/swarm.yml
+++ b/playbooks/swarm.yml
@@ -48,20 +48,6 @@
     - role: centralesupelec.mydocker.gpu_post_docker
       when: gpu_type is defined
 
-- name: Install ssh keys
-  hosts: docker_swarm_worker:docker_swarm_manager
-  tasks:
-    - name: Provision ssh keys
-      when: common_ssh_authorized_keys is defined
-      ansible.posix.authorized_key:
-        user: "{{ item.key }}"
-        state: present
-        key: "{{item.value | join('\n') if item.value is defined and item.value is iterable else ''}}"
-        exclusive: true
-      loop: "{{ (common_ssh_authorized_keys | default({})) | dict2items }}"
-      tags:
-        - ssh
-
 - name: Create and configure docker swarm
   hosts: docker_swarm_manager:docker_swarm_worker
   roles:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -106,6 +106,7 @@
     key: "{{item.value | join('\n') if item.value is defined and item.value is iterable else ''}}"
     exclusive: true
   loop: "{{ (common_ssh_authorized_keys | default({})) | dict2items }}"
+  become: true
   tags:
     - ssh
 ...


### PR DESCRIPTION
- The common task "Provision ssh keys" should run as root, in order to access other `.ssh` users folder
- The swarm playbook contains the same "Provision ssh keys" task. It seems to be useless, as it's already played in `common`role, and may lead to errors if we add keys to non-existing users