### PR TITLE
swarm: fix manager availability by its Swarm id instead of hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project does NOT adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## 0.20.0
+### Fixed
+- Use swarm node id instead of hostname to select the target in a docker_swarm_init task
+
 ## 0.19.0
 ### Changed
 - Set caddy server deployment mode to global and remove node selection based on role

--- a/roles/docker_swarm/tasks/docker_swarm_init.yml
+++ b/roles/docker_swarm/tasks/docker_swarm_init.yml
@@ -74,6 +74,6 @@
 
 - name: Enable Leader scheduling
   community.docker.docker_node:
-    hostname: "{{ ansible_hostname }}"
+    hostname: "{{ docker_info.host_info.Swarm.NodeID }}"
     availability: active
   when: inventory_hostname == groups['docker_swarm_manager'][0]


### PR DESCRIPTION
The ansible hostname may not be the same as the manager hostname in Docker swarm nodes. So we should reference it by it's ID like other tasks of the file.